### PR TITLE
overlay: core: Use Cloudflare DNS as the default fallback

### DIFF
--- a/overlays/CoreResOverlay/Android.bp
+++ b/overlays/CoreResOverlay/Android.bp
@@ -1,0 +1,6 @@
+runtime_resource_overlay {
+    name: "CoreResOverlay",
+    certificate: "platform",
+    sdk_version: "current",
+    product_specific: true
+}

--- a/overlays/CoreResOverlay/AndroidManifest.xml
+++ b/overlays/CoreResOverlay/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?><manifest xmlns:android="http://schemas.android.com/apk/res/android" android:compileSdkVersion="35" android:compileSdkVersionCodename="15" package="com.android.coreres.auto_generated_rro_product__" platformBuildVersionCode="35" platformBuildVersionName="15">
+    <application android:extractNativeLibs="true"/>
+    <overlay android:isStatic="true" android:priority="1" android:targetPackage="com.android.coreres"/>
+</manifest>

--- a/overlays/CoreResOverlay/res/values/config.xml
+++ b/overlays/CoreResOverlay/res/values/config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2022 The Leaf OS Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<resources>
+    <!-- IP address of the dns server to use if nobody else suggests one -->
+    <string name="config_default_dns_server" translatable="false">1.0.0.1</string>
+</resources>

--- a/overlays/build.mk
+++ b/overlays/build.mk
@@ -23,6 +23,7 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
 # System overlays
 PRODUCT_PACKAGES += \
     AndroidOverlay \
+    CoreResOverlay \
     Launcher3Overlay \
     SettingsOverlay \
     SystemUIOverlay


### PR DESCRIPTION
Cloudflare DNS has a better privacy policy than Google Public DNS while still supporting DNS over TLS.

Change-Id: I0e53f50c67deb77568c2926686a550e7c1b4fbd9